### PR TITLE
Modelindex Bug Fixes

### DIFF
--- a/examples/Demo/Display.cpp
+++ b/examples/Demo/Display.cpp
@@ -1,8 +1,8 @@
 #include "Display.h"
 #include "ui_Display.h"
 
-Display::Display(const QModelIndex &index, QListWidgetItem *listItem) :
-    QWidgetsListWidgetDisplay(index, listItem),
+Display::Display(QListWidgetItem *listItem) :
+    QWidgetsListWidgetDisplay(listItem),
     ui(new Ui::Display)
 {
     ui->setupUi(this);

--- a/examples/Demo/Display.h
+++ b/examples/Demo/Display.h
@@ -12,7 +12,7 @@ class Display : public QWidgetsListWidgetDisplay
     Q_OBJECT
 
 public:
-    explicit Display(const QModelIndex &index, QListWidgetItem *listItem);
+    explicit Display(QListWidgetItem *listItem);
     ~Display();
 
 public slots:

--- a/examples/Demo/List.cpp
+++ b/examples/Demo/List.cpp
@@ -6,7 +6,7 @@ List::List(QWidget *parent) : QWidgetsListWidget(parent)
 {
 }
 
-QWidgetsListWidgetDisplay *List::createDisplay(const QModelIndex &index, QListWidgetItem *listItem) const
+QWidgetsListWidgetDisplay *List::createDisplay(QListWidgetItem *listItem) const
 {
-    return new Display(index, listItem);
+    return new Display(listItem);
 }

--- a/examples/Demo/List.h
+++ b/examples/Demo/List.h
@@ -15,7 +15,7 @@ signals:
 public slots:
 
 protected slots:
-    virtual QWidgetsListWidgetDisplay *createDisplay(const QModelIndex &index, QListWidgetItem *listItem) const override;
+    virtual QWidgetsListWidgetDisplay *createDisplay(QListWidgetItem *listItem) const override;
 };
 
 #endif // LIST_H

--- a/src/QWidgetsListWidget.cpp
+++ b/src/QWidgetsListWidget.cpp
@@ -33,7 +33,7 @@ void QWidgetsListWidget::rowsInserted(const QModelIndex &parent, int start, int 
 
         if(itemWidget(listItem) == nullptr) {
             // setItemWidget passes ownership to List's viewport
-            auto widget = createDisplay(indexFromItem(listItem), listItem);
+            auto widget = createDisplay(listItem);
             setItemWidget(listItem, widget);
             listItem->setSizeHint(widget->sizeHint());
         }
@@ -48,7 +48,8 @@ void QWidgetsListWidget::rowsAboutToBeRemoved(const QModelIndex &parent, int sta
         Q_ASSERT(listIndex.isValid());
 
         auto widget = indexWidget(listIndex);
-        if(widget != nullptr) {
+        if(widget != nullptr) 
+		{
             setIndexWidget(listIndex, nullptr);
             widget->deleteLater();
         }
@@ -70,9 +71,9 @@ void QWidgetsListWidget::dataChanged(const QModelIndex &topLeft, const QModelInd
     QListWidget::dataChanged(topLeft, bottomRight, roles);
 }
 
-QWidgetsListWidgetDisplay *QWidgetsListWidget::createDisplay(const QModelIndex &index, QListWidgetItem *listItem) const
+QWidgetsListWidgetDisplay *QWidgetsListWidget::createDisplay(QListWidgetItem *listItem) const
 {
-    return new QWidgetsListWidgetDisplay(index, listItem);
+    return new QWidgetsListWidgetDisplay(listItem);
 }
 
 QModelIndex QWidgetsListWidget::index(int row, int column, const QModelIndex &parent) const

--- a/src/QWidgetsListWidget.h
+++ b/src/QWidgetsListWidget.h
@@ -15,9 +15,9 @@ protected slots:
     virtual void rowsInserted(const QModelIndex &parent, int start, int end) override;
     virtual void rowsAboutToBeRemoved(const QModelIndex &parent, int start, int end);
     virtual void dataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight, const QVector<int> &roles) override;
-    virtual QWidgetsListWidgetDisplay *createDisplay(const QModelIndex &index, QListWidgetItem *listItem) const;
+    virtual QWidgetsListWidgetDisplay *createDisplay(QListWidgetItem *listItem) const;
 
-protected:
+public :
     QModelIndex index(int row, int column = 0, const QModelIndex &parent = QModelIndex()) const;
 };
 

--- a/src/QWidgetsListWidgetDisplay.cpp
+++ b/src/QWidgetsListWidgetDisplay.cpp
@@ -1,8 +1,8 @@
 #include "QWidgetsListWidgetDisplay.h"
+#include "QWidgetsListWidget.h"
 
-QWidgetsListWidgetDisplay::QWidgetsListWidgetDisplay(const QModelIndex &index, QListWidgetItem *listItem) :
+QWidgetsListWidgetDisplay::QWidgetsListWidgetDisplay(QListWidgetItem *listItem) :
     QWidget(0), // parent is always messed around with later anyway
-    m_index(index),
     m_listItem(listItem)
 {
 }
@@ -11,10 +11,12 @@ void QWidgetsListWidgetDisplay::dataChanged()
 {
 }
 
-const QModelIndex &QWidgetsListWidgetDisplay::index() const
+QModelIndex QWidgetsListWidgetDisplay::index() const
 {
-    return m_index;
+	QWidgetsListWidget* pListWidget = static_cast<QWidgetsListWidget*>(listItem()->listWidget());
+	return pListWidget->index(pListWidget->row(listItem()));
 }
+
 QListWidgetItem *QWidgetsListWidgetDisplay::listItem() const
 {
     return m_listItem;

--- a/src/QWidgetsListWidgetDisplay.h
+++ b/src/QWidgetsListWidgetDisplay.h
@@ -9,17 +9,16 @@ class QWidgetsListWidgetDisplay : public QWidget
 {
     Q_OBJECT
 public:
-    explicit QWidgetsListWidgetDisplay(const QModelIndex &index, QListWidgetItem *listItem);
+    explicit QWidgetsListWidgetDisplay(QListWidgetItem *listItem);
 
 public slots:
     virtual void dataChanged();
 
 protected:
-    const QModelIndex &index() const;
+    QModelIndex index() const;
     QListWidgetItem *listItem() const;
 
 private:
-    QModelIndex m_index;
     QListWidgetItem *m_listItem;
 };
 


### PR DESCRIPTION

QModelindex changes when listWidgetitem is removed.
QWidetsListWidgetDisplay should use current modelindex .